### PR TITLE
BUGFIX: Skip char repetition in cleaned up identifiers

### DIFF
--- a/Classes/Model/Factory.php
+++ b/Classes/Model/Factory.php
@@ -66,7 +66,7 @@ final class Factory
          * \p{xx}   A character with the xx unicode property.   https://php.net/manual/en/regexp.reference.escape.php
          * \pL      Every Letter                                https://php.net/manual/en/regexp.reference.unicode.php
          */
-        $cleanupPattern = '%[^\\pL\\d]+%iUum';
+        $cleanupPattern = '%[^\\pL\\d]+%ium';
 
         $subject = (string)preg_replace($cleanupPattern, '-', $subject);
         $subject = trim($subject, '-');


### PR DESCRIPTION
This was supposed to happen right from the start.